### PR TITLE
Use the ARN for the log group output

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ module "app_ecs_service" {
 
 | Name | Description |
 |------|-------------|
-| awslogs_group | Name of the CloudWatch Logs log group containers should use. |
+| awslogs_group | ARN of the CloudWatch Logs log group containers should use. |
 | ecs_security_group_id | Security Group ID assigned to the ECS tasks. |
 | task_execution_role_arn | The ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
 | task_role_arn | The ARN of the IAM role assumed by Amazon ECS container tasks. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,6 @@ output "task_role_name" {
 }
 
 output "awslogs_group" {
-  description = "Name of the CloudWatch Logs log group containers should use."
-  value       = "${local.awslogs_group}"
+  description = "ARN of the CloudWatch Logs log group containers should use."
+  value       = "${aws_cloudwatch_log_group.main.arn}"
 }


### PR DESCRIPTION
Typically, resources can take either the name or the ARN, but the ARN is generally needed more often. The name can be deduced from the ARN.