### PR TITLE
Add target_container_name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: trussworks/circleci-docker-primary:8bc229606f89c509cce44cf0f4299c7473334175
+      - image: trussworks/circleci-docker-primary:4a25f819d871cefc0ab71b09c2598990208a2482
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v1.4.0
+    rev: v2.0.0
     hooks:
       - id: check-json
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -60,45 +60,45 @@ module "app_ecs_service" {
 }
 ```
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alb_security_group | Application Load Balancer (ALB) security group ID to allow traffic from. | string | `` | no |
-| associate_alb | Whether to associate an Application Load Balancer (ALB) with the ECS service. | string | `false` | no |
-| associate_nlb | Whether to associate a Network Load Balancer (NLB) with the ECS service. | string | `false` | no |
-| container_definitions | Container definitions provided as valid JSON document. Default uses nginx:stable. | string | `` | no |
-| container_health_check_port | An additional port on which the container can receive a health check.  Zero means the container port can only receive a health check on the port set by the container_port variable. | string | `0` | no |
-| container_port | The port on which the container will receive traffic. | string | `80` | no |
-| ecs_cluster_arn | The ARN of the ECS cluster. | string | - | yes |
-| ecs_instance_role | The name of the ECS instance role. | string | `` | no |
-| ecs_subnet_ids | Subnet IDs for the ECS tasks. | list | - | yes |
-| ecs_use_fargate | Whether to use Fargate for the task definition. | string | `false` | no |
-| ecs_vpc_id | VPC ID to be used by ECS. | string | - | yes |
+| alb\_security\_group | Application Load Balancer (ALB) security group ID to allow traffic from. | string | `` | no |
+| associate\_alb | Whether to associate an Application Load Balancer (ALB) with the ECS service. | string | `false` | no |
+| associate\_nlb | Whether to associate a Network Load Balancer (NLB) with the ECS service. | string | `false` | no |
+| container\_definitions | Container definitions provided as valid JSON document. Default uses nginx:stable. | string | `` | no |
+| container\_health\_check\_port | An additional port on which the container can receive a health check.  Zero means the container port can only receive a health check on the port set by the container_port variable. | string | `0` | no |
+| container\_port | The port on which the container will receive traffic. | string | `80` | no |
+| ecs\_cluster\_arn | The ARN of the ECS cluster. | string | - | yes |
+| ecs\_instance\_role | The name of the ECS instance role. | string | `` | no |
+| ecs\_subnet\_ids | Subnet IDs for the ECS tasks. | list | - | yes |
+| ecs\_use\_fargate | Whether to use Fargate for the task definition. | string | `false` | no |
+| ecs\_vpc\_id | VPC ID to be used by ECS. | string | - | yes |
 | environment | Environment tag, e.g prod. | string | - | yes |
-| fargate_task_cpu | Number of cpu units used in initial task definition. Default is minimum. | string | `256` | no |
-| fargate_task_memory | Amount (in MiB) of memory used in initiail task definition. Default is minimum. | string | `512` | no |
-| lb_target_group | Either Application Load Balancer (ALB) or Network Load Balancer (NLB) target group ARN tasks will register with. | string | `` | no |
-| logs_cloudwatch_group | CloudWatch log group to create and use. Default: /ecs/{name}-{environment} | string | `` | no |
-| logs_cloudwatch_retention | Number of days you want to retain log events in the log group. | string | `90` | no |
+| fargate\_task\_cpu | Number of cpu units used in initial task definition. Default is minimum. | string | `256` | no |
+| fargate\_task\_memory | Amount (in MiB) of memory used in initiail task definition. Default is minimum. | string | `512` | no |
+| lb\_target\_group | Either Application Load Balancer (ALB) or Network Load Balancer (NLB) target group ARN tasks will register with. | string | `` | no |
+| logs\_cloudwatch\_group | CloudWatch log group to create and use. Default: /ecs/{name}-{environment} | string | `` | no |
+| logs\_cloudwatch\_retention | Number of days you want to retain log events in the log group. | string | `90` | no |
 | name | The service name. | string | - | yes |
-| nlb_subnet_cidr_blocks | List of Network Load Balancer (NLB) CIDR blocks to allow traffic from. | list | `<list>` | no |
-| tasks_desired_count | The number of instances of a task definition. | string | `1` | no |
-| tasks_maximum_percent | Upper limit on the number of running tasks. | string | `200` | no |
-| tasks_minimum_healthy_percent | Lower limit on the number of running tasks. | string | `100` | no |
+| nlb\_subnet\_cidr\_blocks | List of Network Load Balancer (NLB) CIDR blocks to allow traffic from. | list | `<list>` | no |
+| target\_container\_name | Name of the container the Load Balancer should target. Default: {name}-{environment} | string | `` | no |
+| tasks\_desired\_count | The number of instances of a task definition. | string | `1` | no |
+| tasks\_maximum\_percent | Upper limit on the number of running tasks. | string | `200` | no |
+| tasks\_minimum\_healthy\_percent | Lower limit on the number of running tasks. | string | `100` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| awslogs_group | Name of the CloudWatch Logs log group containers should use. |
-| awslogs_group_arn | ARN of the CloudWatch Logs log group containers should use. |
-| ecs_security_group_id | Security Group ID assigned to the ECS tasks. |
-| task_definition_arn | Full ARN of the Task Definition (including both family and revision). |
-| task_definition_family | The family of the Task Definition. |
-| task_execution_role_arn | The ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
-| task_role_arn | The ARN of the IAM role assumed by Amazon ECS container tasks. |
-| task_role_name | The name of the IAM role assumed by Amazon ECS container tasks. |
+| awslogs\_group | Name of the CloudWatch Logs log group containers should use. |
+| awslogs\_group\_arn | ARN of the CloudWatch Logs log group containers should use. |
+| ecs\_security\_group\_id | Security Group ID assigned to the ECS tasks. |
+| task\_definition\_arn | Full ARN of the Task Definition (including both family and revision). |
+| task\_definition\_family | The family of the Task Definition. |
+| task\_execution\_role\_arn | The ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
+| task\_role\_arn | The ARN of the IAM role assumed by Amazon ECS container tasks. |
+| task\_role\_name | The name of the IAM role assumed by Amazon ECS container tasks. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -62,12 +62,13 @@
  */
 
 locals {
-  awslogs_group = "${var.logs_cloudwatch_group == "" ? "/ecs/${var.environment}/${var.name}" : var.logs_cloudwatch_group}"
+  awslogs_group         = "${var.logs_cloudwatch_group == "" ? "/ecs/${var.environment}/${var.name}" : var.logs_cloudwatch_group}"
+  target_container_name = "${var.target_container_name == "" ? "${var.name}-${var.environment}" : var.target_container_name}"
 
   default_container_definitions = <<EOF
 [
   {
-    "name": "${var.name}-${var.environment}",
+    "name": "${local.target_container_name}",
     "image": "nginx:stable",
     "cpu": 128,
     "memory": 128,
@@ -399,7 +400,7 @@ resource "aws_ecs_service" "main" {
 
   load_balancer {
     target_group_arn = "${var.lb_target_group}"
-    container_name   = "${aws_ecs_task_definition.main.family}"
+    container_name   = "${local.target_container_name}"
     container_port   = "${var.container_port}"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -95,6 +95,12 @@ variable "container_definitions" {
   type        = "string"
 }
 
+variable "target_container_name" {
+  description = "Name of the container the Load Balancer should target. Default: {name}-{environment}"
+  default     = ""
+  type        = "string"
+}
+
 variable "associate_alb" {
   description = "Whether to associate an Application Load Balancer (ALB) with the ECS service."
   default     = false


### PR DESCRIPTION
This adds the ability to specify the name of the container you want the load balancer to target. This lets you get away from the baked in default of using the task-family as the container name, which doesn't work well for a multi-container Task Definition where you may want to use a more informative naming scheme to identify your containers.

Additionally, this uses `terraform-docs` v0.5.0 to generate the docs and updates CircleCI to use a more recent primary image (which includes that version).