### PR TITLE
Multiple repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: trussworks/circleci-docker-primary:8734409e869c644343833aa565ef84a792bf6986
+      - image: trussworks/circleci-docker-primary:9bb7cfcfbbcf70fa56051ed5ba71da8a9be75b78
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ module "app_ecs_service" {
 | container\_health\_check\_port | An additional port on which the container can receive a health check.  Zero means the container port can only receive a health check on the port set by the container_port variable. | string | `"0"` | no |
 | container\_image | The image of the container. | string | `"golang:1.12.5-alpine"` | no |
 | container\_port | The port on which the container will receive traffic. | string | `"80"` | no |
-| ecr\_repo\_arn | The ARN of the ECR repo.  By default, allows all repositories. | string | `"*"` | no |
+| ecr\_repo\_arns | The ARNs of the ECR repos.  By default, allows all repositories. | list | `[ "*" ]` | no |
 | ecs\_cluster\_arn | The ARN of the ECS cluster. | string | n/a | yes |
 | ecs\_instance\_role | The name of the ECS instance role. | string | `""` | no |
 | ecs\_subnet\_ids | Subnet IDs for the ECS tasks. | list | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -265,7 +265,7 @@ data "aws_iam_policy_document" "instance_role_policy_doc" {
       "ecr:BatchGetImage",
     ]
 
-    resources = ["${var.ecr_repo_arn}"]
+    resources = ["${var.ecr_repo_arns}"]
   }
 }
 
@@ -317,7 +317,7 @@ data "aws_iam_policy_document" "task_execution_role_policy_doc" {
       "ecr:BatchGetImage",
     ]
 
-    resources = ["${var.ecr_repo_arn}"]
+    resources = ["${var.ecr_repo_arns}"]
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,10 @@ variable "logs_cloudwatch_group" {
   type        = "string"
 }
 
-variable "ecr_repo_arn" {
-  description = "The ARN of the ECR repo.  By default, allows all repositories."
-  type        = "string"
-  default     = "*"
+variable "ecr_repo_arns" {
+  description = "The ARNs of the ECR repos.  By default, allows all repositories."
+  type        = "list"
+  default     = ["*"]
 }
 
 variable "ecs_use_fargate" {


### PR DESCRIPTION
If you share the task execution for the service, you might need to grant the created task execution role, access to multiple repos, e.g., app server and migrations.