### PR TITLE
Add CPU and Mem utilization metric alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ module "app_ecs_service" {
   name        = "app"
   environment = "prod"
 
-  ecs_cluster_arn               = "${module.app_ecs_cluster.ecs_cluster_arn}"
+  ecs_cluster_name              = "cluster-name"
   ecs_vpc_id                    = "${module.vpc.vpc_id}"
   ecs_subnet_ids                = "${module.vpc.private_subnets}"
   tasks_desired_count           = 2
@@ -47,7 +47,7 @@ module "app_ecs_service" {
   name        = "app"
   environment = "prod"
 
-  ecs_cluster_arn               = "${module.app_ecs_cluster.ecs_cluster_arn}"
+  ecs_cluster_name              = "cluster-name"
   ecs_vpc_id                    = "${module.vpc.vpc_id}"
   ecs_subnet_ids                = "${module.vpc.private_subnets}"
   tasks_desired_count           = 2
@@ -67,12 +67,18 @@ module "app_ecs_service" {
 | alb\_security\_group | Application Load Balancer (ALB) security group ID to allow traffic from. | string | `""` | no |
 | associate\_alb | Whether to associate an Application Load Balancer (ALB) with the ECS service. | string | `"false"` | no |
 | associate\_nlb | Whether to associate a Network Load Balancer (NLB) with the ECS service. | string | `"false"` | no |
+| cloudwatch\_alarm\_actions | The list of actions to take for cloudwatch alarms | list | `[]` | no |
+| cloudwatch\_alarm\_cpu\_enable | Enable the CPU Utilization CloudWatch metric alarm | string | `"true"` | no |
+| cloudwatch\_alarm\_cpu\_threshold | The CPU Utilization threshold for the CloudWatch metric alarm | string | `"80"` | no |
+| cloudwatch\_alarm\_mem\_enable | Enable the Memory Utilization CloudWatch metric alarm | string | `"true"` | no |
+| cloudwatch\_alarm\_mem\_threshold | The Memory Utilization threshold for the CloudWatch metric alarm | string | `"80"` | no |
+| cloudwatch\_alarm\_name | Generic name used for CPU and Memory Cloudwatch Alarms | string | `""` | no |
 | container\_definitions | Container definitions provided as valid JSON document. Default uses nginx:stable. | string | `""` | no |
 | container\_health\_check\_port | An additional port on which the container can receive a health check.  Zero means the container port can only receive a health check on the port set by the container_port variable. | string | `"0"` | no |
 | container\_image | The image of the container. | string | `"golang:1.12.5-alpine"` | no |
 | container\_port | The port on which the container will receive traffic. | string | `"80"` | no |
 | ecr\_repo\_arns | The ARNs of the ECR repos.  By default, allows all repositories. | list | `[ "*" ]` | no |
-| ecs\_cluster\_arn | The ARN of the ECS cluster. | string | n/a | yes |
+| ecs\_cluster\_name | The name  of the ECS cluster. | string | n/a | yes |
 | ecs\_instance\_role | The name of the ECS instance role. | string | `""` | no |
 | ecs\_subnet\_ids | Subnet IDs for the ECS tasks. | list | n/a | yes |
 | ecs\_use\_fargate | Whether to use Fargate for the task definition. | string | `"false"` | no |

--- a/README.md
+++ b/README.md
@@ -110,3 +110,18 @@ module "app_ecs_service" {
 | task\_role\_name | The name of the IAM role assumed by Amazon ECS container tasks. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Upgrade Path
+
+### 1.14.0 to 1.15.0
+
+In upgrading to this version you need to pass through the ECS Cluster Name and not the ECS Cluster ARN.
+The difference would be changing `ecs_cluster_arn` to `ecs_cluster_name` and passing in the name info.
+The module will take care of pulling the ARN from the ECS Cluster data resource on your behalf.
+
+If you decide you do not want metric alarms you can also set two more settings:
+
+```hcl
+  cloudwatch_alarm_cpu_enable = false
+  cloudwatch_alarm_mem_enable = false
+```

--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ resource "aws_cloudwatch_log_group" "main" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_cpu" {
-  count = "${var.cloudwatch_alarm_cpu_enable ? 1 : 0}"
+  count = "${var.cloudwatch_alarm_cpu_enable && (var.associate_alb || var.associate_nlb) ? 1 : 0}"
 
   alarm_name        = "${local.cloudwatch_alarm_name}-cpu"
   alarm_description = "Monitors ECS CPU Utilization"
@@ -148,7 +148,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm_cpu" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_mem" {
-  count = "${var.cloudwatch_alarm_mem_enable ? 1 : 0}"
+  count = "${var.cloudwatch_alarm_cpu_enable && (var.associate_alb || var.associate_nlb) ? 1 : 0}"
 
   alarm_name        = "${local.cloudwatch_alarm_name}-mem"
   alarm_description = "Monitors ECS CPU Utilization"
@@ -165,6 +165,48 @@ resource "aws_cloudwatch_metric_alarm" "alarm_mem" {
   dimensions = {
     "ClusterName" = "${var.ecs_cluster_name}"
     "ServiceName" = "${aws_ecs_service.main.name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alarm_cpu_no_lb" {
+  count = "${var.cloudwatch_alarm_cpu_enable && !(var.associate_alb || var.associate_nlb) ? 1 : 0}"
+
+  alarm_name        = "${local.cloudwatch_alarm_name}-cpu"
+  alarm_description = "Monitors ECS CPU Utilization"
+  alarm_actions     = ["${var.cloudwatch_alarm_actions}"]
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "${var.cloudwatch_alarm_cpu_threshold}"
+
+  dimensions = {
+    "ClusterName" = "${var.ecs_cluster_name}"
+    "ServiceName" = "${aws_ecs_service.main_no_lb.name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alarm_mem_no_lb" {
+  count = "${var.cloudwatch_alarm_cpu_enable && !(var.associate_alb || var.associate_nlb) ? 1 : 0}"
+
+  alarm_name        = "${local.cloudwatch_alarm_name}-mem"
+  alarm_description = "Monitors ECS CPU Utilization"
+  alarm_actions     = ["${var.cloudwatch_alarm_actions}"]
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "${var.cloudwatch_alarm_mem_threshold}"
+
+  dimensions = {
+    "ClusterName" = "${var.ecs_cluster_name}"
+    "ServiceName" = "${aws_ecs_service.main_no_lb.name}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,42 @@ variable "environment" {
   type        = "string"
 }
 
+variable "cloudwatch_alarm_name" {
+  description = "Generic name used for CPU and Memory Cloudwatch Alarms"
+  default     = ""
+  type        = "string"
+}
+
+variable "cloudwatch_alarm_actions" {
+  description = "The list of actions to take for cloudwatch alarms"
+  type        = "list"
+  default     = []
+}
+
+variable "cloudwatch_alarm_cpu_enable" {
+  description = "Enable the CPU Utilization CloudWatch metric alarm"
+  type        = "string"
+  default     = true
+}
+
+variable "cloudwatch_alarm_cpu_threshold" {
+  description = "The CPU Utilization threshold for the CloudWatch metric alarm"
+  default     = 80
+  type        = "string"
+}
+
+variable "cloudwatch_alarm_mem_enable" {
+  description = "Enable the Memory Utilization CloudWatch metric alarm"
+  type        = "string"
+  default     = true
+}
+
+variable "cloudwatch_alarm_mem_threshold" {
+  description = "The Memory Utilization threshold for the CloudWatch metric alarm"
+  default     = 80
+  type        = "string"
+}
+
 variable "logs_cloudwatch_retention" {
   description = "Number of days you want to retain log events in the log group."
   default     = 90
@@ -32,8 +68,8 @@ variable "ecs_use_fargate" {
   type        = "string"
 }
 
-variable "ecs_cluster_arn" {
-  description = "The ARN of the ECS cluster."
+variable "ecs_cluster_name" {
+  description = "The name  of the ECS cluster."
   type        = "string"
 }
 


### PR DESCRIPTION
This adds default CPU and Mem utilization metric alarms to this module. By default they are turned on but there are not actions connected so they shouldn't be doing anything.  Things you can do:

1. Turn on or off either CPU or Mem alarm separately
2. Define the thresholds for CPU or Mem separately
3. Define a custom name for the alarms (which they share)

**NOTE BREAKING CHANGE** I needed the Cluster Name which you can't get from the ARN easily. Instead I've changed the module to require the Cluster Name and then derive the ARN from the data object. I'm not sure this warrants changing the major version number though even though the API changes a bit so I'd like to tag as `1.15.0`. I'm open to suggestions on this though.