### PR TITLE
Update container_definition docs to correctly specify default usage if gooalpine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ module "app_ecs_service" {
 | cloudwatch\_alarm\_mem\_enable | Enable the Memory Utilization CloudWatch metric alarm | string | `"true"` | no |
 | cloudwatch\_alarm\_mem\_threshold | The Memory Utilization threshold for the CloudWatch metric alarm | string | `"80"` | no |
 | cloudwatch\_alarm\_name | Generic name used for CPU and Memory Cloudwatch Alarms | string | `""` | no |
-| container\_definitions | Container definitions provided as valid JSON document. Default uses nginx:stable. | string | `""` | no |
+| container\_definitions | Container definitions provided as valid JSON document. Default uses golang:1.12.5-alpine running a simple hello world. | string | `""` | no |
 | container\_health\_check\_port | An additional port on which the container can receive a health check.  Zero means the container port can only receive a health check on the port set by the container_port variable. | string | `"0"` | no |
 | container\_image | The image of the container. | string | `"golang:1.12.5-alpine"` | no |
 | container\_port | The port on which the container will receive traffic. | string | `"80"` | no |

--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm_mem" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_cpu_no_lb" {
-  count = "${var.cloudwatch_alarm_cpu_enable && !(var.associate_alb || var.associate_nlb) ? 1 : 0}"
+  count = "${var.cloudwatch_alarm_cpu_enable && ! (var.associate_alb || var.associate_nlb) ? 1 : 0}"
 
   alarm_name        = "${local.cloudwatch_alarm_name}-cpu"
   alarm_description = "Monitors ECS CPU Utilization"
@@ -190,7 +190,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm_cpu_no_lb" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_mem_no_lb" {
-  count = "${var.cloudwatch_alarm_cpu_enable && !(var.associate_alb || var.associate_nlb) ? 1 : 0}"
+  count = "${var.cloudwatch_alarm_cpu_enable && ! (var.associate_alb || var.associate_nlb) ? 1 : 0}"
 
   alarm_name        = "${local.cloudwatch_alarm_name}-mem"
   alarm_description = "Monitors ECS CPU Utilization"
@@ -506,7 +506,7 @@ resource "aws_ecs_service" "main" {
   # Use latest active revision
   task_definition = "${aws_ecs_task_definition.main.family}:${max(
     "${aws_ecs_task_definition.main.revision}",
-    "${data.aws_ecs_task_definition.main.revision}")}"
+  "${data.aws_ecs_task_definition.main.revision}")}"
 
   desired_count                      = "${var.tasks_desired_count}"
   deployment_minimum_healthy_percent = "${var.tasks_minimum_healthy_percent}"
@@ -546,7 +546,7 @@ resource "aws_ecs_service" "main_no_lb" {
   # Use latest active revision
   task_definition = "${aws_ecs_task_definition.main.family}:${max(
     "${aws_ecs_task_definition.main.revision}",
-    "${data.aws_ecs_task_definition.main.revision}")}"
+  "${data.aws_ecs_task_definition.main.revision}")}"
 
   desired_count                      = "${var.tasks_desired_count}"
   deployment_minimum_healthy_percent = "${var.tasks_minimum_healthy_percent}"

--- a/variables.tf
+++ b/variables.tf
@@ -138,7 +138,7 @@ variable "container_health_check_port" {
 }
 
 variable "container_definitions" {
-  description = "Container definitions provided as valid JSON document. Default uses nginx:stable."
+  description = "Container definitions provided as valid JSON document. Default uses golang:1.12.5-alpine running a simple hello world."
   default     = ""
   type        = "string"
 }


### PR DESCRIPTION
We stopped defaulting to nginx:stable a while ago, update the variable container_definition to reflect that.