### PR TITLE
Adding Terraform Versions section to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ to validate the initial infrastructure is working: visiting the site shows
 a simple Go hello world page. We expect deployments to manage the container
 definitions going forward, not Terraform.
 
+## Terraform Versions
+
+Terraform 0.12. Pin module version to ~> 2.0. Submit pull-requests to master branch.
+
+Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform011 branch.
+
 ## Usage
 
 ### ECS service associated with an Application Load Balancer (ALB)

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,12 @@
  * a simple Go hello world page. We expect deployments to manage the container
  * definitions going forward, not Terraform.
  *
+ * ## Terraform Versions
+ *
+ * Terraform 0.12. Pin module version to ~> 2.0. Submit pull-requests to master branch.
+ *
+ * Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform011 branch.
+ *
  * ## Usage
  *
  * ### ECS service associated with an Application Load Balancer (ALB)


### PR DESCRIPTION
Ugh, merged this before pushing these changes. This finishes up the work for the tf12 release.