### PR TITLE
fix to support /health path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ definitions going forward, not Terraform.
 
 ## Terraform Versions
 
-Terraform 0.12. Pin module version to ~> 2.0. Submit pull-requests to master branch.
+Terraform 0.12. Pin module version to ~> 2.0.1. Submit pull-requests to master branch.
 
-Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform011 branch.
+Terraform 0.11. Pin module version to ~> 1.14.0. Submit pull-requests to terraform011 branch.
 
 ## Usage
 

--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ locals {
     "entryPoint": [
       "/bin/sh",
       "-c",
-      "echo 'cGFja2FnZSBtYWluCgppbXBvcnQgKAoJImZtdCIKCSJsb2ciCgkibmV0L2h0dHAiCgkib3MiCgkic3RyY29udiIKKQoKZnVuYyBtYWluKCkgewoKCXBvcnQsIGVyciA6PSBzdHJjb252LkF0b2kob3MuR2V0ZW52KCJQT1JUIikpCglpZiBlcnIgIT0gbmlsIHsKCQlwYW5pYyhlcnIpCgl9CglodHRwLkhhbmRsZUZ1bmMoIi8iLCBmdW5jKHcgaHR0cC5SZXNwb25zZVdyaXRlciwgciAqaHR0cC5SZXF1ZXN0KSB7CgkJZm10LkZwcmludGYodywgIkhlbGxvLCB3b3JsZCEiKQoJfSkKCWZtdC5QcmludGxuKCJMaXN0ZW5pbmcgb24gcG9ydCIsIHBvcnQpCglsb2cuRmF0YWwoaHR0cC5MaXN0ZW5BbmRTZXJ2ZShmbXQuU3ByaW50ZigiOiVkIiwgcG9ydCksIG5pbCkpCn0K' | base64 -d > helloworld.go && go run helloworld.go"
+      "echo 'cGFja2FnZSBtYWluCgppbXBvcnQgKAoJImZtdCIKCSJsb2ciCgkibmV0L2h0dHAiCgkib3MiCgkic3RyY29udiIKKQoKZnVuYyBtYWluKCkgewoJcG9ydCwgZXJyIDo9IHN0cmNvbnYuQXRvaShvcy5HZXRlbnYoIlBPUlQiKSkKCWlmIGVyciAhPSBuaWwgewoJCXBhbmljKGVycikKCX0KCWZtdC5QcmludGxuKCJMaXN0ZW5pbmcgb24gcG9ydCIsIHBvcnQpCglsb2cuRmF0YWwoaHR0cC5MaXN0ZW5BbmRTZXJ2ZShmbXQuU3ByaW50ZigiOiVkIiwgcG9ydCksIGh0dHAuSGFuZGxlckZ1bmMoZnVuYyh3IGh0dHAuUmVzcG9uc2VXcml0ZXIsIHIgKmh0dHAuUmVxdWVzdCkgewogICAgZm10LkZwcmludGYodywgIkhlbGxvLCB3b3JsZCEiKQogIH0pKSkKfQo=' | base64 -d > helloworld.go && go run helloworld.go"
     ]
   }
 ]
@@ -601,4 +601,3 @@ resource "aws_ecs_service" "main_no_lb" {
     ignore_changes = [task_definition]
   }
 }
-


### PR DESCRIPTION
This PR fixes the initial placeholder to correctly respond to all url paths, including `/health`, which is what the ALB uses for health checks by default.  Without this fix, the ALB may assume the container is unhealthy and continue to recycle it.

```
package main

import (
	"fmt"
	"log"
	"net/http"
	"os"
	"strconv"
)

func main() {
	port, err := strconv.Atoi(os.Getenv("PORT"))
	if err != nil {
		panic(err)
	}
	fmt.Println("Listening on port", port)
	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
    fmt.Fprintf(w, "Hello, world!")
  })))
}
```