### PR TITLE
security group requires a list of strings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -593,7 +593,7 @@ resource "aws_ecs_service" "main_no_lb" {
 
   network_configuration {
     subnets          = var.ecs_subnet_ids
-    security_groups  = aws_security_group.ecs_sg.id
+    security_groups  = [aws_security_group.ecs_sg.id]
     assign_public_ip = false
   }
 


### PR DESCRIPTION
fixes an issue where an error is thrown when an ecs services requires neither an ALB or an NLB, the network configuration requires a list of strings.

```
Error: Incorrect attribute value type

  on .terraform/modules/ecs_service_horizon/trussworks-terraform-aws-ecs-service-f7c5910/main.tf line 596, in resource "aws_ecs_service" "main_no_lb":
 596:     security_groups  = aws_security_group.ecs_sg.id

Inappropriate value for attribute "security_groups": set of string required.


Error: Incorrect attribute value type

  on .terraform/modules/ecs_service_scheduler/trussworks-terraform-aws-ecs-service-f7c5910/main.tf line 596, in resource "aws_ecs_service" "main_no_lb":
 596:     security_groups  = aws_security_group.ecs_sg.id

Inappropriate value for attribute "security_groups": set of string required.
```