### PR TITLE
Encrypt ECS service logs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.19.0
+    rev: v1.21.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
@@ -26,5 +26,3 @@ repos:
     rev: v1.21.0
     hooks:
       - id: golangci-lint
-        entry: golangci-lint run --verbose
-        verbose: true

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ module "app_ecs_service" {
 | environment | Environment tag, e.g prod. | string | n/a | yes |
 | fargate\_task\_cpu | Number of cpu units used in initial task definition. Default is minimum. | string | `"256"` | no |
 | fargate\_task\_memory | Amount (in MiB) of memory used in initial task definition. Default is minimum. | string | `"512"` | no |
-| kms\_key\_id | KMS customer managed key (CMK) ID for encrypting application logs. | string | n/a | yes |
+| kms\_key\_id | KMS customer managed key (CMK) ARN for encrypting application logs. | string | n/a | yes |
 | lb\_target\_group | Either Application Load Balancer (ALB) or Network Load Balancer (NLB) target group ARN tasks will register with. | string | `""` | no |
 | logs\_cloudwatch\_group | CloudWatch log group to create and use. Default: /ecs/{name}-{environment} | string | `""` | no |
 | logs\_cloudwatch\_retention | Number of days you want to retain log events in the log group. | string | `"90"` | no |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ module "app_ecs_service" {
 | environment | Environment tag, e.g prod. | string | n/a | yes |
 | fargate\_task\_cpu | Number of cpu units used in initial task definition. Default is minimum. | string | `"256"` | no |
 | fargate\_task\_memory | Amount (in MiB) of memory used in initial task definition. Default is minimum. | string | `"512"` | no |
+| kms\_key\_id | KMS customer managed key (CMK) ID for encrypting application logs. | string | `""` | no |
 | lb\_target\_group | Either Application Load Balancer (ALB) or Network Load Balancer (NLB) target group ARN tasks will register with. | string | `""` | no |
 | logs\_cloudwatch\_group | CloudWatch log group to create and use. Default: /ecs/{name}-{environment} | string | `""` | no |
 | logs\_cloudwatch\_retention | Number of days you want to retain log events in the log group. | string | `"90"` | no |

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,7 @@
  *   ecs_cluster                   = aws_ecs_cluster.mycluster
  *   ecs_vpc_id                    = module.vpc.vpc_id
  *   ecs_subnet_ids                = module.vpc.private_subnets
+ *   kms_key_id                    = aws_kms_key.main.arn
  *   tasks_desired_count           = 2
  *   tasks_minimum_healthy_percent = 50
  *   tasks_maximum_percent         = 200
@@ -56,6 +57,7 @@
  *   ecs_cluster                   = aws_ecs_cluster.mycluster
  *   ecs_vpc_id                    = module.vpc.vpc_id
  *   ecs_subnet_ids                = module.vpc.private_subnets
+ *   kms_key_id                    = aws_kms_key.main.arn
  *   tasks_desired_count           = 2
  *   tasks_minimum_healthy_percent = 50
  *   tasks_maximum_percent         = 200
@@ -122,7 +124,7 @@ resource "aws_cloudwatch_log_group" "main" {
   name              = local.awslogs_group
   retention_in_days = var.logs_cloudwatch_retention
 
-  kms_key_id = var.kms_key_id != "" ? var.kms_key_id : null
+  kms_key_id = var.kms_key_id
 
   tags = {
     Name        = "${var.name}-${var.environment}"

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,7 @@ resource "aws_cloudwatch_log_group" "main" {
   name              = local.awslogs_group
   retention_in_days = var.logs_cloudwatch_retention
 
-  kms_key_id = var.kms_key_id ? var.kms_key_id : null
+  kms_key_id = var.kms_key_id != "" ? var.kms_key_id : null
 
   tags = {
     Name        = "${var.name}-${var.environment}"

--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,8 @@ resource "aws_cloudwatch_log_group" "main" {
   name              = local.awslogs_group
   retention_in_days = var.logs_cloudwatch_retention
 
+  kms_key_id = var.kms_key_id ? var.kms_key_id : null
+
   tags = {
     Name        = "${var.name}-${var.environment}"
     Environment = var.environment

--- a/variables.tf
+++ b/variables.tf
@@ -183,6 +183,6 @@ variable "nlb_subnet_cidr_blocks" {
 }
 
 variable "kms_key_id" {
-  description = "KMS customer managed key (CMK) ID for encrypting application logs."
+  description = "KMS customer managed key (CMK) ARN for encrypting application logs."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -184,6 +184,5 @@ variable "nlb_subnet_cidr_blocks" {
 
 variable "kms_key_id" {
   description = "KMS customer managed key (CMK) ID for encrypting application logs."
-  default     = ""
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -182,3 +182,8 @@ variable "nlb_subnet_cidr_blocks" {
   type        = list(string)
 }
 
+variable "kms_key_id" {
+  description = "KMS customer managed key (CMK) ID for encrypting application logs."
+  default     = ""
+  type        = string
+}


### PR DESCRIPTION
This let's folks encrypt their logs if they provide a key. It has no breaking API change so I'll likely just increment the minor version.