### PR TITLE
Expose the execution role name as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ module "app_ecs_service" {
 | task\_definition\_arn | Full ARN of the Task Definition (including both family and revision). |
 | task\_definition\_family | The family of the Task Definition. |
 | task\_execution\_role\_arn | The ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
+| task\_execution\_role\_name | The name of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
 | task\_role\_arn | The ARN of the IAM role assumed by Amazon ECS container tasks. |
 | task\_role\_name | The name of the IAM role assumed by Amazon ECS container tasks. |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "task_execution_role_arn" {
   value       = join("", aws_iam_role.task_execution_role.*.arn)
 }
 
+output "task_execution_role_name" {
+  description = "The name of the task execution role that the Amazon ECS container agent and the Docker daemon can assume."
+  value       = join("", aws_iam_role.task_execution_role.*.name)
+}
+
 output "task_role_arn" {
   description = "The ARN of the IAM role assumed by Amazon ECS container tasks."
   value       = aws_iam_role.task_role.arn


### PR DESCRIPTION
In order to update the execution role by attaching another policy I need access to the name. 