### PR TITLE
add assign_public_id variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:tf12-4c1fd54273446484259597ae3da9deb2806498ed
+      - image: trussworks/circleci-docker-primary:tf12-672ec2f55496635ab60b47e2b2e12f1333c88c7c
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ module "app_ecs_service" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alb\_security\_group | Application Load Balancer (ALB) security group ID to allow traffic from. | string | `""` | no |
-| associate\_alb | Whether to associate an Application Load Balancer (ALB) with the ECS service. | string | `"false"` | no |
-| associate\_nlb | Whether to associate a Network Load Balancer (NLB) with the ECS service. | string | `"false"` | no |
+| alb\_security\_group | Application Load Balancer \(ALB\) security group ID to allow traffic from. | string | `""` | no |
+| assign\_public\_ip | Whether this instance should be accessible from the public internet. Default is false. | string | `"false"` | no |
+| associate\_alb | Whether to associate an Application Load Balancer \(ALB\) with the ECS service. | string | `"false"` | no |
+| associate\_nlb | Whether to associate a Network Load Balancer \(NLB\) with the ECS service. | string | `"false"` | no |
 | cloudwatch\_alarm\_actions | The list of actions to take for cloudwatch alarms | list | `[]` | no |
 | cloudwatch\_alarm\_cpu\_enable | Enable the CPU Utilization CloudWatch metric alarm | string | `"true"` | no |
 | cloudwatch\_alarm\_cpu\_threshold | The CPU Utilization threshold for the CloudWatch metric alarm | string | `"80"` | no |
@@ -82,7 +83,7 @@ module "app_ecs_service" {
 | cloudwatch\_alarm\_mem\_threshold | The Memory Utilization threshold for the CloudWatch metric alarm | string | `"80"` | no |
 | cloudwatch\_alarm\_name | Generic name used for CPU and Memory Cloudwatch Alarms | string | `""` | no |
 | container\_definitions | Container definitions provided as valid JSON document. Default uses golang:1.12.5-alpine running a simple hello world. | string | `""` | no |
-| container\_health\_check\_port | An additional port on which the container can receive a health check.  Zero means the container port can only receive a health check on the port set by the container_port variable. | string | `"0"` | no |
+| container\_health\_check\_port | An additional port on which the container can receive a health check.  Zero means the container port can only receive a health check on the port set by the container\_port variable. | string | `"0"` | no |
 | container\_image | The image of the container. | string | `"golang:1.12.5-alpine"` | no |
 | container\_port | The port on which the container will receive traffic. | string | `"80"` | no |
 | ecr\_repo\_arns | The ARNs of the ECR repos.  By default, allows all repositories. | list(string) | `[ "*" ]` | no |
@@ -93,14 +94,14 @@ module "app_ecs_service" {
 | ecs\_vpc\_id | VPC ID to be used by ECS. | string | n/a | yes |
 | environment | Environment tag, e.g prod. | string | n/a | yes |
 | fargate\_task\_cpu | Number of cpu units used in initial task definition. Default is minimum. | string | `"256"` | no |
-| fargate\_task\_memory | Amount (in MiB) of memory used in initial task definition. Default is minimum. | string | `"512"` | no |
-| kms\_key\_id | KMS customer managed key (CMK) ARN for encrypting application logs. | string | n/a | yes |
-| lb\_target\_group | Either Application Load Balancer (ALB) or Network Load Balancer (NLB) target group ARN tasks will register with. | string | `""` | no |
-| logs\_cloudwatch\_group | CloudWatch log group to create and use. Default: /ecs/{name}-{environment} | string | `""` | no |
+| fargate\_task\_memory | Amount \(in MiB\) of memory used in initial task definition. Default is minimum. | string | `"512"` | no |
+| kms\_key\_id | KMS customer managed key \(CMK\) ARN for encrypting application logs. | string | n/a | yes |
+| lb\_target\_group | Either Application Load Balancer \(ALB\) or Network Load Balancer \(NLB\) target group ARN tasks will register with. | string | `""` | no |
+| logs\_cloudwatch\_group | CloudWatch log group to create and use. Default: /ecs/\{name\}-\{environment\} | string | `""` | no |
 | logs\_cloudwatch\_retention | Number of days you want to retain log events in the log group. | string | `"90"` | no |
 | name | The service name. | string | n/a | yes |
-| nlb\_subnet\_cidr\_blocks | List of Network Load Balancer (NLB) CIDR blocks to allow traffic from. | list(string) | `[]` | no |
-| target\_container\_name | Name of the container the Load Balancer should target. Default: {name}-{environment} | string | `""` | no |
+| nlb\_subnet\_cidr\_blocks | List of Network Load Balancer \(NLB\) CIDR blocks to allow traffic from. | list(string) | `[]` | no |
+| target\_container\_name | Name of the container the Load Balancer should target. Default: \{name\}-\{environment\} | string | `""` | no |
 | tasks\_desired\_count | The number of instances of a task definition. | string | `"1"` | no |
 | tasks\_maximum\_percent | Upper limit on the number of running tasks. | string | `"200"` | no |
 | tasks\_minimum\_healthy\_percent | Lower limit on the number of running tasks. | string | `"100"` | no |
@@ -112,7 +113,7 @@ module "app_ecs_service" {
 | awslogs\_group | Name of the CloudWatch Logs log group containers should use. |
 | awslogs\_group\_arn | ARN of the CloudWatch Logs log group containers should use. |
 | ecs\_security\_group\_id | Security Group ID assigned to the ECS tasks. |
-| task\_definition\_arn | Full ARN of the Task Definition (including both family and revision). |
+| task\_definition\_arn | Full ARN of the Task Definition \(including both family and revision\). |
 | task\_definition\_family | The family of the Task Definition. |
 | task\_execution\_role\_arn | The ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
 | task\_execution\_role\_name | The name of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ module "app_ecs_service" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | alb\_security\_group | Application Load Balancer \(ALB\) security group ID to allow traffic from. | string | `""` | no |
-| assign\_public\_ip | Whether this instance should be accessible from the public internet. Default is false. | string | `"false"` | no |
-| associate\_alb | Whether to associate an Application Load Balancer \(ALB\) with the ECS service. | string | `"false"` | no |
-| associate\_nlb | Whether to associate a Network Load Balancer \(NLB\) with the ECS service. | string | `"false"` | no |
+| assign\_public\_ip | Whether this instance should be accessible from the public internet. Default is false. | bool | `"false"` | no |
+| associate\_alb | Whether to associate an Application Load Balancer \(ALB\) with the ECS service. | bool | `"false"` | no |
+| associate\_nlb | Whether to associate a Network Load Balancer \(NLB\) with the ECS service. | bool | `"false"` | no |
 | cloudwatch\_alarm\_actions | The list of actions to take for cloudwatch alarms | list | `[]` | no |
-| cloudwatch\_alarm\_cpu\_enable | Enable the CPU Utilization CloudWatch metric alarm | string | `"true"` | no |
+| cloudwatch\_alarm\_cpu\_enable | Enable the CPU Utilization CloudWatch metric alarm | bool | `"true"` | no |
 | cloudwatch\_alarm\_cpu\_threshold | The CPU Utilization threshold for the CloudWatch metric alarm | string | `"80"` | no |
 | cloudwatch\_alarm\_mem\_enable | Enable the Memory Utilization CloudWatch metric alarm | string | `"true"` | no |
 | cloudwatch\_alarm\_mem\_threshold | The Memory Utilization threshold for the CloudWatch metric alarm | string | `"80"` | no |
@@ -90,7 +90,7 @@ module "app_ecs_service" {
 | ecs\_cluster | ECS cluster object for this task. | object | n/a | yes |
 | ecs\_instance\_role | The name of the ECS instance role. | string | `""` | no |
 | ecs\_subnet\_ids | Subnet IDs for the ECS tasks. | list(string) | n/a | yes |
-| ecs\_use\_fargate | Whether to use Fargate for the task definition. | string | `"false"` | no |
+| ecs\_use\_fargate | Whether to use Fargate for the task definition. | bool | `"false"` | no |
 | ecs\_vpc\_id | VPC ID to be used by ECS. | string | n/a | yes |
 | environment | Environment tag, e.g prod. | string | n/a | yes |
 | fargate\_task\_cpu | Number of cpu units used in initial task definition. Default is minimum. | string | `"256"` | no |

--- a/main.tf
+++ b/main.tf
@@ -541,7 +541,7 @@ resource "aws_ecs_service" "main" {
   network_configuration {
     subnets          = var.ecs_subnet_ids
     security_groups  = [aws_security_group.ecs_sg.id]
-    assign_public_ip = var.assign_public_ipse
+    assign_public_ip = var.assign_public_ip
   }
 
   load_balancer {

--- a/main.tf
+++ b/main.tf
@@ -541,7 +541,7 @@ resource "aws_ecs_service" "main" {
   network_configuration {
     subnets          = var.ecs_subnet_ids
     security_groups  = [aws_security_group.ecs_sg.id]
-    assign_public_ip = false
+    assign_public_ip = var.assign_public_ipse
   }
 
   load_balancer {

--- a/main.tf
+++ b/main.tf
@@ -598,7 +598,7 @@ resource "aws_ecs_service" "main_no_lb" {
   network_configuration {
     subnets          = var.ecs_subnet_ids
     security_groups  = [aws_security_group.ecs_sg.id]
-    assign_public_ip = false
+    assign_public_ip = var.assign_public_ip
   }
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -22,8 +22,8 @@ variable "cloudwatch_alarm_actions" {
 
 variable "cloudwatch_alarm_cpu_enable" {
   description = "Enable the CPU Utilization CloudWatch metric alarm"
-  type        = "string"
   default     = true
+  type        = bool
 }
 
 variable "cloudwatch_alarm_cpu_threshold" {
@@ -65,7 +65,7 @@ variable "ecr_repo_arns" {
 variable "ecs_use_fargate" {
   description = "Whether to use Fargate for the task definition."
   default     = false
-  type        = string
+  type        = bool
 }
 
 variable "ecs_cluster" {
@@ -95,7 +95,7 @@ variable "ecs_subnet_ids" {
 variable "assign_public_ip" {
   description = "Whether this instance should be accessible from the public internet. Default is false."
   default     = false
-  type        = string
+  type        = bool
 }
 
 variable "fargate_task_cpu" {
@@ -161,13 +161,13 @@ variable "target_container_name" {
 variable "associate_alb" {
   description = "Whether to associate an Application Load Balancer (ALB) with the ECS service."
   default     = false
-  type        = string
+  type        = bool
 }
 
 variable "associate_nlb" {
   description = "Whether to associate a Network Load Balancer (NLB) with the ECS service."
   default     = false
-  type        = string
+  type        = bool
 }
 
 variable "alb_security_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,12 @@ variable "ecs_subnet_ids" {
   type        = list(string)
 }
 
+variable "assign_public_ip" {
+  description = "Whether this instance should be accessible from the public internet. Default is false."
+  default     = false
+  type        = string
+}
+
 variable "fargate_task_cpu" {
   description = "Number of cpu units used in initial task definition. Default is minimum."
   default     = 256


### PR DESCRIPTION
Corresponds to [this ticket](https://www.pivotaltracker.com/story/show/170562656)

In order to make it possible to make ECS accessible from the public internet, needed to create a module variable to pass into the `assign_public_ips` internal variable. This blocks other work.

One question:
we're inconsistent about using bools vs strings as var types in tf12; I stuck with what we're using elsewhere in the module, but can update the whole module to use bools instead. What do you think?

Formatting for a number of these variables was autoupdated on commit via pre commit hooks.