### PR TITLE
Output IAM role(s) object from module rather than just name.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -19,8 +19,13 @@ output "task_role_name" {
 }
 
 output "task_role" {
-  description = "The IAM role assumed by Amazon ECS container tasks."
+  description = "The IAM role object assumed by Amazon ECS container tasks."
   value       = aws_iam_role.task_role
+}
+
+output "task_execution_role" {
+  description = "The role object of the task execution role that the Amazon ECS container agent and the Docker daemon can assume."
+  value       = aws_iam_role.task_execution_role
 }
 
 output "task_definition_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "task_role_name" {
   value       = aws_iam_role.task_role.name
 }
 
+output "task_role" {
+  description = "The IAM role assumed by Amazon ECS container tasks."
+  value       = aws_iam_role.task_role
+}
+
 output "task_definition_arn" {
   description = "Full ARN of the Task Definition (including both family and revision)."
   value       = aws_ecs_task_definition.main.arn


### PR DESCRIPTION
This PR adds a module output of the IAM role the module creates. This address an issue where the name of the IAM role and required other consumers to do a `data` lookup of a resource not yet created that TF could not manage in the dependency graph.

Follow up notes:
1. Debating to have a conditional output on the task execution role. Since it is conditional it returns an array with the role object. Not sure best way to clean this up.
1. Do we have a changelog for the repo? If not any objections to adding one?