### PR TITLE
Output IAM role(s) object from module rather than just name

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,10 @@ module "app_ecs_service" {
 | ecs\_security\_group\_id | Security Group ID assigned to the ECS tasks. |
 | task\_definition\_arn | Full ARN of the Task Definition (including both family and revision). |
 | task\_definition\_family | The family of the Task Definition. |
+| task\_execution\_role | The role object of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
 | task\_execution\_role\_arn | The ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
 | task\_execution\_role\_name | The name of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |
+| task\_role | The IAM role object assumed by Amazon ECS container tasks. |
 | task\_role\_arn | The ARN of the IAM role assumed by Amazon ECS container tasks. |
 | task\_role\_name | The name of the IAM role assumed by Amazon ECS container tasks. |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,11 @@ output "task_role_name" {
   value       = aws_iam_role.task_role.name
 }
 
+output "task_role" {
+  description = "The IAM role assumed by Amazon ECS container tasks."
+  value       = aws_iam_role.task_role
+}
+
 output "task_definition_arn" {
   description = "Full ARN of the Task Definition (including both family and revision)."
   value       = aws_ecs_task_definition.main.arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,8 +24,13 @@ output "task_role_name" {
 }
 
 output "task_role" {
-  description = "The IAM role assumed by Amazon ECS container tasks."
+  description = "The IAM role object assumed by Amazon ECS container tasks."
   value       = aws_iam_role.task_role
+}
+
+output "task_execution_role" {
+  description = "The role object of the task execution role that the Amazon ECS container agent and the Docker daemon can assume."
+  value       = aws_iam_role.task_execution_role
 }
 
 output "task_definition_arn" {


### PR DESCRIPTION
This PR adds a module output of the IAM role the module creates. This address an issue where the name of the IAM role and required other consumers to do a `data` lookup of a resource not yet created that TF could not manage in the dependency graph.

This is a follow up to https://github.com/trussworks/terraform-aws-ecs-service/pull/45 but not from a fork so CircleCI will run.