### PR TITLE
Additional security group memberships for ECS service (v11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ module "app_ecs_service" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| additional\_security\_group\_ids | In addition to the security group created for the service, a list of security groups the ECS service should also be added to. | list | `[]` | no |
 | alb\_security\_group | Application Load Balancer (ALB) security group ID to allow traffic from. | string | `""` | no |
 | associate\_alb | Whether to associate an Application Load Balancer (ALB) with the ECS service. | string | `"false"` | no |
 | associate\_nlb | Whether to associate a Network Load Balancer (NLB) with the ECS service. | string | `"false"` | no |

--- a/main.tf
+++ b/main.tf
@@ -493,6 +493,8 @@ locals {
 
     FARGATE = []
   }
+
+  ecs_service_agg_security_groups = ["${compact(concat(list(aws_security_group.ecs_sg.id), var.additional_security_group_ids))}"]
 }
 
 resource "aws_ecs_service" "main" {
@@ -517,7 +519,7 @@ resource "aws_ecs_service" "main" {
 
   network_configuration {
     subnets          = ["${var.ecs_subnet_ids}"]
-    security_groups  = ["${aws_security_group.ecs_sg.id}"]
+    security_groups  = ["${local.ecs_service_agg_security_groups}"]
     assign_public_ip = false
   }
 
@@ -557,7 +559,7 @@ resource "aws_ecs_service" "main_no_lb" {
 
   network_configuration {
     subnets          = ["${var.ecs_subnet_ids}"]
-    security_groups  = ["${aws_security_group.ecs_sg.id}"]
+    security_groups  = ["${local.ecs_service_agg_security_groups}"]
     assign_public_ip = false
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -178,3 +178,9 @@ variable "nlb_subnet_cidr_blocks" {
   default     = []
   type        = "list"
 }
+
+variable "additional_security_group_ids" {
+  description = "In addition to the security group created for the service, a list of security groups the ECS service should also be added to."
+  default     = []
+  type        = "list"
+}


### PR DESCRIPTION
While it is possible to attach the security group created in the module to an existing SG, there is a (soft) limit of 60 rules in a security group. Additionally, such a long security group can get unwieldy at scale. This PR adds the ability to pass in additional SG's where the ECS service will have direct membership. 

* Add the additional_security_group_ids variable
* Aggregate var.additional_security_group_ids with created SG id for passing to aws_ecs_service
* Update docs