### PR TITLE
Additional security group memberships for ECS service (v12)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:40076395a6e6a349f92caa92c4de614e105fe672
+      - image: trussworks/circleci-docker-primary:ad6a12218e3a892bdbbb23fca175bfb826f61871
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ module "app_ecs_service" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| additional\_security\_group\_ids | In addition to the security group created for the service, a list of security groups the ECS service should also be added to. | list | `[]` | no |
 | alb\_security\_group | Application Load Balancer (ALB) security group ID to allow traffic from. | `string` | `""` | no |
 | assign\_public\_ip | Whether this instance should be accessible from the public internet. Default is false. | `bool` | `false` | no |
 | associate\_alb | Whether to associate an Application Load Balancer (ALB) with the ECS service. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ module "app_ecs_service" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
-| additional\_security\_group\_ids | In addition to the security group created for the service, a list of security groups the ECS service should also be added to. | list | `[]` | no |
+| additional\_security\_group\_ids | In addition to the security group created for the service, a list of security groups the ECS service should also be added to. | `list(string)` | `[]` | no |
 | alb\_security\_group | Application Load Balancer (ALB) security group ID to allow traffic from. | `string` | `""` | no |
 | assign\_public\_ip | Whether this instance should be accessible from the public internet. Default is false. | `bool` | `false` | no |
 | associate\_alb | Whether to associate an Application Load Balancer (ALB) with the ECS service. | `bool` | `false` | no |
@@ -93,8 +93,8 @@ module "app_ecs_service" {
 | container\_health\_check\_port | An additional port on which the container can receive a health check.  Zero means the container port can only receive a health check on the port set by the container\_port variable. | `string` | `0` | no |
 | container\_image | The image of the container. | `string` | `"golang:alpine"` | no |
 | container\_port | The port on which the container will receive traffic. | `string` | `80` | no |
-| ecr\_repo\_arns | The ARNs of the ECR repos.  By default, allows all repositories. | `list(string)` | <pre>[<br>  "*"<br>]<br></pre> | no |
-| ecs\_cluster | ECS cluster object for this task. | <pre>object({<br>    arn  = string<br>    name = string<br>  })<br></pre> | n/a | yes |
+| ecr\_repo\_arns | The ARNs of the ECR repos.  By default, allows all repositories. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| ecs\_cluster | ECS cluster object for this task. | <pre>object({<br>    arn  = string<br>    name = string<br>  })</pre> | n/a | yes |
 | ecs\_instance\_role | The name of the ECS instance role. | `string` | `""` | no |
 | ecs\_subnet\_ids | Subnet IDs for the ECS tasks. | `list(string)` | n/a | yes |
 | ecs\_use\_fargate | Whether to use Fargate for the task definition. | `bool` | `false` | no |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -85,17 +85,27 @@ module "ecs-service" {
   ecs_vpc_id       = module.vpc.vpc_id
   ecs_use_fargate  = true
   assign_public_ip = true
+  additional_security_group_ids = [
+    aws_security_group.ecs_allow_http.id
+  ]
 
   kms_key_id = aws_kms_key.main.arn
 }
 
 #
-# SG adjustment
+# Allow HTTP access to the ECS instance from the internet
 #
+
+resource "aws_security_group" "ecs_allow_http" {
+  name        = "ecs-allow-http"
+  description = "Allow inbound HTTP to the ECS instance"
+  vpc_id      = module.vpc.vpc_id
+
+}
 
 resource "aws_security_group_rule" "ecs_allow_http" {
   description       = "Allow HTTP"
-  security_group_id = module.ecs-service.ecs_security_group_id
+  security_group_id = aws_security_group.ecs_allow_http.id
 
   type        = "ingress"
   from_port   = local.container_port

--- a/main.tf
+++ b/main.tf
@@ -471,7 +471,7 @@ resource "aws_ecs_service" "main" {
 
   network_configuration {
     subnets          = var.ecs_subnet_ids
-    security_groups  = [local.ecs_service_agg_security_groups]
+    security_groups  = local.ecs_service_agg_security_groups
     assign_public_ip = var.assign_public_ip
   }
 
@@ -528,7 +528,7 @@ resource "aws_ecs_service" "main_no_lb" {
 
   network_configuration {
     subnets          = var.ecs_subnet_ids
-    security_groups  = [local.ecs_service_agg_security_groups]
+    security_groups  = local.ecs_service_agg_security_groups
     assign_public_ip = var.assign_public_ip
   }
 

--- a/main.tf
+++ b/main.tf
@@ -431,7 +431,7 @@ locals {
     FARGATE = []
   }
 
-  ecs_service_agg_security_groups = [compact(concat(list(aws_security_group.ecs_sg.id), var.additional_security_group_ids))]
+  ecs_service_agg_security_groups = compact(concat(list(aws_security_group.ecs_sg.id), var.additional_security_group_ids))
 }
 
 resource "aws_ecs_service" "main" {

--- a/main.tf
+++ b/main.tf
@@ -430,6 +430,8 @@ locals {
     ]
     FARGATE = []
   }
+
+  ecs_service_agg_security_groups = [compact(concat(list(aws_security_group.ecs_sg.id), var.additional_security_group_ids))]
 }
 
 resource "aws_ecs_service" "main" {
@@ -469,7 +471,7 @@ resource "aws_ecs_service" "main" {
 
   network_configuration {
     subnets          = var.ecs_subnet_ids
-    security_groups  = [aws_security_group.ecs_sg.id]
+    security_groups  = [local.ecs_service_agg_security_groups]
     assign_public_ip = var.assign_public_ip
   }
 
@@ -526,7 +528,7 @@ resource "aws_ecs_service" "main_no_lb" {
 
   network_configuration {
     subnets          = var.ecs_subnet_ids
-    security_groups  = [aws_security_group.ecs_sg.id]
+    security_groups  = [local.ecs_service_agg_security_groups]
     assign_public_ip = var.assign_public_ip
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -192,3 +192,9 @@ variable "kms_key_id" {
   description = "KMS customer managed key (CMK) ARN for encrypting application logs."
   type        = string
 }
+
+variable "additional_security_group_ids" {
+  description = "In addition to the security group created for the service, a list of security groups the ECS service should also be added to."
+  default     = []
+  type        = list(string)
+}


### PR DESCRIPTION
While it is possible to attach the security group created in the module to an existing SG, there is a (soft) limit of 60 rules in a security group. Additionally, such a long security group can get unwieldy at scale. This PR adds the ability to pass in additional SG's where the ECS service will have direct membership.

* Add the additional_security_group_ids variable
* Aggregate var.additional_security_group_ids with created SG id for passing to aws_ecs_service
* Update docs