### PR TITLE
Fix flaky ENI tests

### DIFF
--- a/test/terraform_aws_ecs_service_test.go
+++ b/test/terraform_aws_ecs_service_test.go
@@ -79,7 +79,7 @@ func GetEniE(t *testing.T, region string, cluster string, taskArns []*string) (*
 
 	maxRetries := 3
 	retryDuration, _ := time.ParseDuration("30s")
-	_, err = retry.DoWithRetryE(t, "Get tasks", maxRetries, retryDuration,
+	_, err = retry.DoWithRetryE(t, "Get public elastic network interface", maxRetries, retryDuration,
 		func() (string, error) {
 			returnedTasks, _ := ecsClient.DescribeTasks(params)
 			errMessage := "failed to look up public elastic network interface"


### PR DESCRIPTION
Occasionally when running the tests, we fail to look up the public ENI. This PR adds retry logic to that part of the test code. 