### PR TITLE
add support for service_registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ No requirements.
 | logs\_cloudwatch\_retention | Number of days you want to retain log events in the log group. | `number` | `90` | no |
 | name | The service name. | `string` | n/a | yes |
 | nlb\_subnet\_cidr\_blocks | List of Network Load Balancer (NLB) CIDR blocks to allow traffic from. | `list(string)` | `[]` | no |
+| service\_registries | List of service registry objects as per <https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries-1>. List can only have a single object until <https://github.com/terraform-providers/terraform-provider-aws/issues/9573> is resolved. | <pre>list(object({<br>    registry_arn   = string<br>    container_name = string<br>    container_port = number<br>    port           = number<br>  }))</pre> | `[]` | no |
 | target\_container\_name | Name of the container the Load Balancer should target. Default: {name}-{environment} | `string` | `""` | no |
 | tasks\_desired\_count | The number of instances of a task definition. | `number` | `1` | no |
 | tasks\_maximum\_percent | Upper limit on the number of running tasks. | `number` | `200` | no |

--- a/main.tf
+++ b/main.tf
@@ -526,6 +526,16 @@ resource "aws_ecs_service" "main" {
     }
   }
 
+  dynamic service_registries {
+    for_each = var.service_registries
+    content {
+      registry_arn   = service_registries.value.registry_arn
+      container_name = service_registries.value.container_name
+      container_port = service_registries.value.container_port
+      port = service_registries.value.port
+    }
+  }
+
   lifecycle {
     ignore_changes = [task_definition]
   }
@@ -575,6 +585,16 @@ resource "aws_ecs_service" "main_no_lb" {
     subnets          = var.ecs_subnet_ids
     security_groups  = local.ecs_service_agg_security_groups
     assign_public_ip = var.assign_public_ip
+  }
+
+    dynamic service_registries {
+    for_each = var.service_registries
+    content {
+      registry_arn   = service_registries.value.registry_arn
+      container_name = service_registries.value.container_name
+      container_port = service_registries.value.container_port
+      port = service_registries.value.port
+    }
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -532,7 +532,7 @@ resource "aws_ecs_service" "main" {
       registry_arn   = service_registries.value.registry_arn
       container_name = service_registries.value.container_name
       container_port = service_registries.value.container_port
-      port = service_registries.value.port
+      port           = service_registries.value.port
     }
   }
 
@@ -587,13 +587,13 @@ resource "aws_ecs_service" "main_no_lb" {
     assign_public_ip = var.assign_public_ip
   }
 
-    dynamic service_registries {
+  dynamic service_registries {
     for_each = var.service_registries
     content {
       registry_arn   = service_registries.value.registry_arn
       container_name = service_registries.value.container_name
       container_port = service_registries.value.container_port
-      port = service_registries.value.port
+      port           = service_registries.value.port
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -199,3 +199,14 @@ variable "hello_world_container_ports" {
   type        = list(number)
   default     = [8080, 8081]
 }
+
+variable "service_registries" {
+  description = "List of service registry objects as per https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries-1. List can only have a single object until https://github.com/terraform-providers/terraform-provider-aws/issues/9573 is resolved."
+  type = list(object({
+    registry_arn  = string
+    container_name = string
+    container_port = number
+    port = number
+  }))
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -201,12 +201,12 @@ variable "hello_world_container_ports" {
 }
 
 variable "service_registries" {
-  description = "List of service registry objects as per https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries-1. List can only have a single object until https://github.com/terraform-providers/terraform-provider-aws/issues/9573 is resolved."
+  description = "List of service registry objects as per <https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries-1>. List can only have a single object until <https://github.com/terraform-providers/terraform-provider-aws/issues/9573> is resolved."
   type = list(object({
-    registry_arn  = string
+    registry_arn   = string
     container_name = string
     container_port = number
-    port = number
+    port           = number
   }))
   default = []
 }


### PR DESCRIPTION
Add support for service registries https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries-1

Note: there is an open HashiCorp bug that only allows one service_registries block at the moment.
https://github.com/terraform-providers/terraform-provider-aws/issues/9573