### PR TITLE
Pin aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,16 @@ module "app_ecs_service" {
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | ~> 2.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.70 |
 
 ## Inputs
 

--- a/examples/load-balancer/providers.tf
+++ b/examples/load-balancer/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  version = "~> 2.70"
+}

--- a/examples/no-load-balancer/providers.tf
+++ b/examples/no-load-balancer/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  version = "~> 2.70"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    aws = "~> 2.70"
+  }
+}


### PR DESCRIPTION
[Pivotal Story](https://www.pivotaltracker.com/story/show/174129036)
Terratest (or maybe terraform) implicitly chooses the version of a provider to use if its not declared when a test is run. So if an AWS resource is used it will download the latest version of the AWS provider and use it.

This is causing issues in terratest so we need to pin the aws provider version