### PR TITLE
fix the memory alert

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -122,10 +122,10 @@ resource "aws_cloudwatch_metric_alarm" "alarm_cpu" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_mem" {
-  count = var.cloudwatch_alarm_cpu_enable && (var.associate_alb || var.associate_nlb) ? 1 : 0
+  count = var.cloudwatch_alarm_mem_enable && (var.associate_alb || var.associate_nlb) ? 1 : 0
 
   alarm_name        = "${local.cloudwatch_alarm_name}-mem"
-  alarm_description = "Monitors ECS CPU Utilization"
+  alarm_description = "Monitors ECS memory Utilization"
   alarm_actions     = var.cloudwatch_alarm_actions
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -146,7 +146,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm_cpu_no_lb" {
   count = var.cloudwatch_alarm_cpu_enable && ! (var.associate_alb || var.associate_nlb) ? 1 : 0
 
   alarm_name        = "${local.cloudwatch_alarm_name}-cpu"
-  alarm_description = "Monitors ECS CPU Utilization"
+  alarm_description = "Monitors ECS CPU Utilization when no load balancer is attached"
   alarm_actions     = var.cloudwatch_alarm_actions
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -164,10 +164,10 @@ resource "aws_cloudwatch_metric_alarm" "alarm_cpu_no_lb" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_mem_no_lb" {
-  count = var.cloudwatch_alarm_cpu_enable && ! (var.associate_alb || var.associate_nlb) ? 1 : 0
+  count = var.cloudwatch_alarm_mem_enable && ! (var.associate_alb || var.associate_nlb) ? 1 : 0
 
   alarm_name        = "${local.cloudwatch_alarm_name}-mem"
-  alarm_description = "Monitors ECS CPU Utilization"
+  alarm_description = "Monitors ECS memory Utilization when no load balancer is attached"
   alarm_actions     = var.cloudwatch_alarm_actions
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -415,7 +415,7 @@ resource "aws_iam_role_policy" "task_execution_role_policy" {
 data "aws_region" "current" {
 }
 
-# Create a task definition with a golang image so the ecs service can be easily
+# Create a task definition with a golang image so the ecs service can be
 # tested. We expect deployments will manage the future container definitions.
 resource "aws_ecs_task_definition" "main" {
   family        = "${var.name}-${var.environment}"


### PR DESCRIPTION
This PR does a few things:

1. Create the memory alarm when `cloudwatch_alarm_mem_enable` is enabled rather than `cloudwatch_alarm_cpu_enable`.
1. Fix the alarm description of two alarms to make it clear what they are used for.
1. Remove the word `easily`. Ease is subjective.