### PR TITLE
Support for Fargate platform_version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,17 +12,17 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.2
+    rev: v0.25.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.31.0
+    rev: v1.45.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.30.0
+    rev: v1.33.0
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ module "app_ecs_service" {
 | ecs\_use\_fargate | Whether to use Fargate for the task definition. | `bool` | `false` | no |
 | ecs\_vpc\_id | VPC ID to be used by ECS. | `string` | n/a | yes |
 | environment | Environment tag, e.g prod. | `string` | n/a | yes |
+| fargate\_platform\_version | The platform version on which to run your service. Only applicable when using Fargate launch type. | `string` | `"LATEST"` | no |
 | fargate\_task\_cpu | Number of cpu units used in initial task definition. Default is minimum. | `number` | `256` | no |
 | fargate\_task\_memory | Amount (in MiB) of memory used in initial task definition. Default is minimum. | `number` | `512` | no |
 | hello\_world\_container\_ports | List of ports for the hello world container app to listen on. The app currently supports listening on two ports. | `list(number)` | <pre>[<br>  8080,<br>  8081<br>]</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -448,7 +448,8 @@ data "aws_ecs_task_definition" "main" {
 }
 
 locals {
-  ecs_service_launch_type = var.ecs_use_fargate ? "FARGATE" : "EC2"
+  ecs_service_launch_type  = var.ecs_use_fargate ? "FARGATE" : "EC2"
+  fargate_platform_version = var.ecs_use_fargate ? var.fargate_platform_version : null
 
   ecs_service_ordered_placement_strategy = {
     EC2 = [
@@ -482,7 +483,8 @@ resource "aws_ecs_service" "main" {
   name    = var.name
   cluster = var.ecs_cluster.arn
 
-  launch_type = local.ecs_service_launch_type
+  launch_type      = local.ecs_service_launch_type
+  platform_version = local.fargate_platform_version
 
   # Use latest active revision
   task_definition = "${aws_ecs_task_definition.main.family}:${max(
@@ -550,7 +552,8 @@ resource "aws_ecs_service" "main_no_lb" {
   name    = var.name
   cluster = var.ecs_cluster.arn
 
-  launch_type = local.ecs_service_launch_type
+  launch_type      = local.ecs_service_launch_type
+  platform_version = local.fargate_platform_version
 
   # Use latest active revision
   task_definition = "${aws_ecs_task_definition.main.family}:${max(

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,12 @@ variable "assign_public_ip" {
   type        = bool
 }
 
+variable "fargate_platform_version" {
+  description = "The platform version on which to run your service. Only applicable when using Fargate launch type."
+  default     = "LATEST"
+  type        = string
+}
+
 variable "fargate_task_cpu" {
   description = "Number of cpu units used in initial task definition. Default is minimum."
   default     = 256


### PR DESCRIPTION
With the availability of Fargate 1.4.0, provide support for setting the platform version to something other than `LATEST`.