### PR TITLE
Relax AWS provider for TF0.12: 3.x is out and works just fine

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ module "app_ecs_service" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.70 |
+| aws | >= 2.70, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.70 |
+| aws | >= 2.70, < 4.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.0"
 
   required_providers {
-    aws = "~> 2.70"
+    aws = ">= 2.70, < 4.0"
   }
 }


### PR DESCRIPTION
This PR relaxes the version constraints for the AWS provider to permit the Terraform 0.12 branch to use AWS provider 3.x in addition to the previously permitted 2.70+ - the existing constraint is unnecessarily restrictive.