### PR TITLE
Fix cloudwatch arn 3.x provider issue in 3.3.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -314,7 +314,9 @@ data "aws_iam_policy_document" "instance_role_policy_doc" {
       "logs:PutLogEvents",
     ]
 
-    resources = [aws_cloudwatch_log_group.main.arn]
+    # Ensure that the arn always includes a ':*' suffix to be compatible with both AWS 2.x and 3.x providers
+    # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#removal-of-arn-wildcard-suffix
+    resources = ["${replace(aws_cloudwatch_log_group.main.arn, "/:\\*$/", "")}:*"]
   }
 
   statement {
@@ -366,7 +368,7 @@ data "aws_iam_policy_document" "task_execution_role_policy_doc" {
       "logs:PutLogEvents",
     ]
 
-    resources = [aws_cloudwatch_log_group.main.arn]
+    resources = ["${replace(aws_cloudwatch_log_group.main.arn, "/:\\*$/", "")}:*"]
   }
 
   statement {


### PR DESCRIPTION
### Issue
3.3.0 added support for AWS providers 2.x and 3.x. If you apply using a 3.x provider the cloudwatch ARNs get their suffix removed as shown in the plan below. See this [3.x upgrade note](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#removal-of-arn-wildcard-suffix). 

```
  ~ resource "aws_iam_role_policy" "task_execution_role_policy" {
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                        Action   = [
                            "logs:PutLogEvents",
                            "logs:CreateLogStream",
                        ]
                        Effect   = "Allow"
                      ~ Resource = "arn:aws:logs:::log-group:/ecs/my-log-group:*" -> "arn:aws:logs:::log-group:/ecs/my-log-group"
                        Sid      = ""
                    }
```

### Fix
This ensures that the suffix is always included with both 2.x and 3.x providers and is based on this [issue comment](https://github.com/hashicorp/terraform-provider-aws/pull/14214#issuecomment-670548936).