### PR TITLE
log to stdout when default hello world go container spins up

### DIFF
--- a/examples/helloworld.go
+++ b/examples/helloworld.go
@@ -28,7 +28,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
 	log.Print("Starting default hello world go container...")
 	log.Print("Hello World")
 

--- a/examples/helloworld.go
+++ b/examples/helloworld.go
@@ -29,6 +29,9 @@ func main() {
 		panic(err)
 	}
 
+	log.Print("Starting default hello world go container...")
+	log.Print("Hello World")
+
 	finish := make(chan bool)
 
 	server1 := http.NewServeMux()


### PR DESCRIPTION
 ### Emit logs to stdout when example hello world go container spins up

Use case: I brought up ecs service without an alb online. I expected the default task to hydrate cloudwatch logs once the container spun up successfully. This PR adds that sanity check. 