### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module "app_ecs_service" {
 
   associate_alb      = true
   alb_security_group = module.security_group.id
-  target_groups =
+  lb_target_groups =
   [
     {
       container_port              = 8443


### PR DESCRIPTION
Changed `target_groups` to `lb_target_groups` in the ALB-example to match the actual parameter.

`target_groups` is not defined, and the rest of the documentation states that `lb_target_groups` is used for either an ALB or NLB.