### PR TITLE
feature: add ecs_service_id ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ No modules.
 | <a name="output_awslogs_group"></a> [awslogs\_group](#output\_awslogs\_group) | Name of the CloudWatch Logs log group containers should use. |
 | <a name="output_awslogs_group_arn"></a> [awslogs\_group\_arn](#output\_awslogs\_group\_arn) | ARN of the CloudWatch Logs log group containers should use. |
 | <a name="output_ecs_security_group_id"></a> [ecs\_security\_group\_id](#output\_ecs\_security\_group\_id) | Security Group ID assigned to the ECS tasks. |
+| <a name="output_ecs_service_id"></a> [ecs\_service\_id](#output\_ecs\_service\_id) | ARN of the ECS service. |
 | <a name="output_task_definition_arn"></a> [task\_definition\_arn](#output\_task\_definition\_arn) | Full ARN of the Task Definition (including both family and revision). |
 | <a name="output_task_definition_family"></a> [task\_definition\_family](#output\_task\_definition\_family) | The family of the Task Definition. |
 | <a name="output_task_execution_role"></a> [task\_execution\_role](#output\_task\_execution\_role) | The role object of the task execution role that the Amazon ECS container agent and the Docker daemon can assume. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,3 +53,7 @@ output "awslogs_group_arn" {
   value       = aws_cloudwatch_log_group.main.arn
 }
 
+output "ecs_service_id" {
+  description = "ARN of the ECS service."
+  value       = aws_ecs_service.main.id
+}


### PR DESCRIPTION
Hi!

This PR adds a new output `ecs_service_id` which is, as the name suggests, the ID (ARN) of the service created by the resource `aws_ecs_service.main.id`.

Rationale:
Tooling around the service/task definitions sometimes need to know the ARN of the service to perform their functions. In my specific case I am trying to integrate [this GitHub action](https://github.com/aws-actions/amazon-ecs-deploy-task-definition#permissions) with a service created by this module. GitHub accesses AWS via an IAM user/role, which is generated by terraform, and therefore I want terraform to reference outputs for task_role_name and task_execution_role_name (already provided by the module) and this new output for the service itself.