### PR TITLE
actually just run dependency updates on the weekends only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,8 +48,7 @@
   ],
   "prConcurrentLimit": 2,
   "schedule": [
-    "every weekend",
-    "after 9am and before 5pm"
+    "every weekend"
   ],
   "separateMinorPatch": true,
   "timezone": "America/Los_Angeles"


### PR DESCRIPTION
Before this PR, renovate would run on weekends and during business hours. This just cuts it over to weekends only.