### PR TITLE
feat: Volume capability with task definition and ability to utilise own execution role

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ No modules.
 | <a name="input_tasks_desired_count"></a> [tasks\_desired\_count](#input\_tasks\_desired\_count) | The number of instances of a task definition. | `number` | `1` | no |
 | <a name="input_tasks_maximum_percent"></a> [tasks\_maximum\_percent](#input\_tasks\_maximum\_percent) | Upper limit on the number of running tasks. | `number` | `200` | no |
 | <a name="input_tasks_minimum_healthy_percent"></a> [tasks\_minimum\_healthy\_percent](#input\_tasks\_minimum\_healthy\_percent) | Lower limit on the number of running tasks. | `number` | `100` | no |
+| <a name="volumes"></a> [volumes](#volumes) | Configuration block for volumes that containers in your task may use. | `list` | `[]` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -443,7 +443,6 @@ resource "aws_ecs_task_definition" "main" {
       requires_compatibilities,
       cpu,
       memory,
-      execution_role_arn,
       container_definitions,
     ]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -234,3 +234,13 @@ variable "health_check_grace_period_seconds" {
   default     = null
   type        = number
 }
+
+variable "volumes" {
+  default     = []
+  description = "Configuration block for volumes that containers in your task may use."
+}
+
+variable "execution_role_arn" {
+  description = "The Amazon Resource Name (ARN) of the task execution role that the Amazon ECS container agent and the Docker daemon can assume."
+  default     = null
+}


### PR DESCRIPTION
PR allows use of your own execution role and allows update without the require to destroy the task definition first (removal from lifecycle ignore_changes. 

Have added the ability to use volumes which didn't exist before.