### PR TITLE
add task definition volume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ No modules.
 | <a name="input_cloudwatch_alarm_name"></a> [cloudwatch\_alarm\_name](#input\_cloudwatch\_alarm\_name) | Generic name used for CPU and Memory Cloudwatch Alarms | `string` | `""` | no |
 | <a name="input_container_definitions"></a> [container\_definitions](#input\_container\_definitions) | Container definitions provided as valid JSON document. Default uses golang:alpine running a simple hello world. | `string` | `""` | no |
 | <a name="input_container_image"></a> [container\_image](#input\_container\_image) | The image of the container. | `string` | `"golang:alpine"` | no |
+| <a name="input_container_volumes"></a> [container\_volumes](#input\_container\_volumes) | Volumes that containers in your task may use. | <pre>list(<br>    object({<br>      name = string<br>    })<br>  )</pre> | `[]` | no |
 | <a name="input_ec2_create_task_execution_role"></a> [ec2\_create\_task\_execution\_role](#input\_ec2\_create\_task\_execution\_role) | Set to true to create ecs task execution role to ECS EC2 Tasks. | `bool` | `false` | no |
 | <a name="input_ecr_repo_arns"></a> [ecr\_repo\_arns](#input\_ecr\_repo\_arns) | The ARNs of the ECR repos.  By default, allows all repositories. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_ecs_cluster"></a> [ecs\_cluster](#input\_ecs\_cluster) | ECS cluster object for this task. | <pre>object({<br>    arn  = string<br>    name = string<br>  })</pre> | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -449,6 +449,13 @@ resource "aws_ecs_task_definition" "main" {
 
   container_definitions = var.container_definitions == "" ? local.default_container_definitions : var.container_definitions
 
+  dynamic "volume" {
+    for_each = var.container_volumes
+    content {
+      name = volume.value.name
+    }
+  }
+
   lifecycle {
     ignore_changes = [
       requires_compatibilities,

--- a/variables.tf
+++ b/variables.tf
@@ -206,6 +206,17 @@ variable "lb_target_groups" {
   )
 }
 
+variable "container_volumes" {
+  description = "Volumes that containers in your task may use."
+  default     = []
+  type = list(
+    object({
+      name = string
+    })
+  )
+
+}
+
 variable "hello_world_container_ports" {
   description = "List of ports for the hello world container app to listen on. The app currently supports listening on two ports."
   type        = list(number)


### PR DESCRIPTION
Issue: https://github.com/trussworks/terraform-aws-ecs-service/issues/307

Add ability to define volumes on the task definition that can be used by containers. 

See AWS documentation on ECS volumes
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html

Note this PR only adds support of simple container bind mount volumes as this is all that I need and I didn't want to bloat the PR. However the PR can easily be extended to other types of volumes (ie. docker, efs etc... see terraform [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition#volume)) easily much like this PR if needed https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/pull/159


 