### PR TITLE
deprecate older terraform versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,6 @@ repos:
     hooks:
       - id: shell-lint
 
-  - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.16.0"
-    hooks:
-      - id: terraform-docs-go
-        args: ["markdown", "table", "--output-file", "README.md", "."]
-
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.77.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ module "app_ecs_service" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 1.0 |
 | aws | >= 3.34 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ modify the `hello_world_container_ports` variable.
 In production usage, we expect deployment tooling to manage the container
 definitions going forward, not Terraform.
 
-## Terraform Versions
-
-Terraform 0.13 and 0.14. Pin module version to ~> 6.0. Submit pull-requests to master branch.
-
-Terraform 0.12 is deprecated.
-
 ## Usage
 
 ### ECS service associated with an Application Load Balancer (ALB)

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
-   Modified README
-   Set expected terraform version to be equal or greater than Terraform version 1.0
