### PR TITLE
Service Discovery optional attributes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         exclude: README.m(ark)?d(own)?
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
+    rev: v0.35.0
     hooks:
       - id: markdownlint
 
@@ -35,6 +35,6 @@ repos:
       - id: shell-lint
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
+    rev: v1.81.0
     hooks:
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ No modules.
 | manage\_ecs\_security\_group | Enable creation and management of the ECS security group and rules | `bool` | `true` | no |
 | name | The service name. | `string` | n/a | yes |
 | nlb\_subnet\_cidr\_blocks | List of Network Load Balancer (NLB) CIDR blocks to allow traffic from. | `list(string)` | `[]` | no |
-| service\_registries | List of service registry objects as per <https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries-1>. List can only have a single object until <https://github.com/terraform-providers/terraform-provider-aws/issues/9573> is resolved. | ```list(object({ registry_arn = string container_name = string container_port = number port = number }))``` | `[]` | no |
+| service\_registries | List of service registry objects as per <https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries-1>. List can only have a single object until <https://github.com/terraform-providers/terraform-provider-aws/issues/9573> is resolved. Either provide container\_name and container\_port or port | ```list(object({ registry_arn = string container_name = optional(string) container_port = optional(number) port = optional(number) }))``` | `[]` | no |
 | target\_container\_name | Name of the container the Load Balancer should target. Default: {name}-{environment} | `string` | `""` | no |
 | tasks\_desired\_count | The number of instances of a task definition. | `number` | `1` | no |
 | tasks\_maximum\_percent | Upper limit on the number of running tasks. | `number` | `200` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -224,12 +224,12 @@ variable "hello_world_container_ports" {
 }
 
 variable "service_registries" {
-  description = "List of service registry objects as per <https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries-1>. List can only have a single object until <https://github.com/terraform-providers/terraform-provider-aws/issues/9573> is resolved."
+  description = "List of service registry objects as per <https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries-1>. List can only have a single object until <https://github.com/terraform-providers/terraform-provider-aws/issues/9573> is resolved. Either provide container_name and container_port or port"
   type = list(object({
     registry_arn   = string
-    container_name = string
-    container_port = number
-    port           = number
+    container_name = optional(string)
+    container_port = optional(number)
+    port           = optional(number)
   }))
   default = []
 }


### PR DESCRIPTION
For service discovery, you can specify either the `container_name` and `container_port` or just `port`. You cannot specify all of them.

The error is

```
Specify a value for either 'port' or the 'containerName' and 'containerPort' combination, but not both
```

Without this change, the error is

```
│ The given value is not suitable for
│ module ...
│ declared at
│ ...
│ element 0: attribute "port" is required.
```
