### PR TITLE
Allow configuring managed tags and deployment circuit breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,13 @@ No modules.
 | ec2\_create\_task\_execution\_role | Set to true to create ecs task execution role to ECS EC2 Tasks. | `bool` | `false` | no |
 | ecr\_repo\_arns | The ARNs of the ECR repos.  By default, allows all repositories. | `list(string)` | ```[ "*" ]``` | no |
 | ecs\_cluster | ECS cluster object for this task. | ```object({ arn = string name = string })``` | n/a | yes |
+| ecs\_deployment\_circuit\_breaker | Configure the ecs deployment circuit breaker | ```object({ enable = bool rollback = bool })``` | ```{ "enable": false, "rollback": false }``` | no |
 | ecs\_exec\_enable | Enable the ability to execute commands on the containers via Amazon ECS Exec | `bool` | `false` | no |
 | ecs\_instance\_role | The name of the ECS instance role. | `string` | `""` | no |
 | ecs\_subnet\_ids | Subnet IDs for the ECS tasks. | `list(string)` | n/a | yes |
 | ecs\_use\_fargate | Whether to use Fargate for the task definition. | `bool` | `false` | no |
 | ecs\_vpc\_id | VPC ID to be used by ECS. | `string` | n/a | yes |
+| enable\_ecs\_managed\_tags | Specifies whether to enable Amazon ECS managed tags for the tasks within the service | `bool` | `false` | no |
 | environment | Environment tag, e.g prod. | `string` | n/a | yes |
 | fargate\_platform\_version | The platform version on which to run your service. Only applicable when using Fargate launch type. | `string` | `"LATEST"` | no |
 | fargate\_task\_cpu | Number of cpu units used in initial task definition. Default is minimum. | `number` | `256` | no |

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ No modules.
 | ec2\_create\_task\_execution\_role | Set to true to create ecs task execution role to ECS EC2 Tasks. | `bool` | `false` | no |
 | ecr\_repo\_arns | The ARNs of the ECR repos.  By default, allows all repositories. | `list(string)` | ```[ "*" ]``` | no |
 | ecs\_cluster | ECS cluster object for this task. | ```object({ arn = string name = string })``` | n/a | yes |
-| ecs\_deployment\_circuit\_breaker | Configure the ecs deployment circuit breaker | ```object({ enable = bool rollback = bool })``` | ```{ "enable": false, "rollback": false }``` | no |
+| ecs\_deployment\_circuit\_breaker | Configure the ECS deployment circuit breaker | ```object({ enable = bool rollback = bool })``` | ```{ "enable": false, "rollback": false }``` | no |
 | ecs\_exec\_enable | Enable the ability to execute commands on the containers via Amazon ECS Exec | `bool` | `false` | no |
 | ecs\_instance\_role | The name of the ECS instance role. | `string` | `""` | no |
 | ecs\_subnet\_ids | Subnet IDs for the ECS tasks. | `list(string)` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -557,6 +557,8 @@ resource "aws_ecs_service" "main" {
 
   enable_ecs_managed_tags = var.enable_ecs_managed_tags
 
+  deployment_circuit_breaker = var.deployment_circuit_breaker
+
   dynamic "service_registries" {
     for_each = var.service_registries
     content {

--- a/main.tf
+++ b/main.tf
@@ -555,6 +555,8 @@ resource "aws_ecs_service" "main" {
 
   health_check_grace_period_seconds = var.associate_alb || var.associate_nlb ? var.health_check_grace_period_seconds : null
 
+  enable_ecs_managed_tags = var.enable_ecs_managed_tags
+
   dynamic "service_registries" {
     for_each = var.service_registries
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -257,3 +257,15 @@ variable "enable_ecs_managed_tags" {
   default     = false
   type        = bool
 }
+
+variable "ecs_deployment_circuit_breaker" {
+  description = "Configure the ecs deployment circuit breaker"
+  type = object({
+    enable   = bool
+    rollback = bool
+  })
+  default = {
+    enable   = false
+    rollback = false
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -259,7 +259,7 @@ variable "enable_ecs_managed_tags" {
 }
 
 variable "ecs_deployment_circuit_breaker" {
-  description = "Configure the ecs deployment circuit breaker"
+  description = "Configure the ECS deployment circuit breaker"
   type = object({
     enable   = bool
     rollback = bool

--- a/variables.tf
+++ b/variables.tf
@@ -251,3 +251,9 @@ variable "ecs_exec_enable" {
   default     = false
   type        = bool
 }
+
+variable "enable_ecs_managed_tags" {
+  description = "Specifies whether to enable Amazon ECS managed tags for the tasks within the service"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
* Allow configuring [enable_ecs_managed_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#enable_ecs_managed_tags)
* Allow configuring [deployment_circuit_breaker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#deployment_circuit_breaker)