### PR TITLE
Fix thinko in deployment circuit breaker reference

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -557,7 +557,7 @@ resource "aws_ecs_service" "main" {
 
   enable_ecs_managed_tags = var.enable_ecs_managed_tags
 
-  deployment_circuit_breaker = var.deployment_circuit_breaker
+  deployment_circuit_breaker = var.ecs_deployment_circuit_breaker
 
   dynamic "service_registries" {
     for_each = var.service_registries


### PR DESCRIPTION
Use the right variable name for configuring the deployment circuit breaker