### PR TITLE
Update required aws provider version for ecs_managed_tags, deployment_circuit_breaker is a block

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ module "app_ecs_service" {
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0 |
-| aws | >= 3.34 |
+| aws | >= 4.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.34 |
+| aws | >= 4.6.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -557,7 +557,10 @@ resource "aws_ecs_service" "main" {
 
   enable_ecs_managed_tags = var.enable_ecs_managed_tags
 
-  deployment_circuit_breaker = var.ecs_deployment_circuit_breaker
+  deployment_circuit_breaker {
+    enable   = var.ecs_deployment_circuit_breaker.enable
+    rollback = var.ecs_deployment_circuit_breaker.rollback
+  }
 
   dynamic "service_registries" {
     for_each = var.service_registries

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.34"
+      version = ">= 4.6.0"
     }
   }
 }


### PR DESCRIPTION
Update the required provider version needed for ecs_managed_tags