### PR TITLE
feat: Allow ECS module to set availability_zone_relancing flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -510,9 +510,10 @@ resource "aws_ecs_service" "main" {
   name    = var.name
   cluster = var.ecs_cluster.arn
 
-  launch_type            = local.ecs_service_launch_type
-  platform_version       = local.fargate_platform_version
-  enable_execute_command = var.ecs_exec_enable
+  launch_type                   = local.ecs_service_launch_type
+  platform_version              = local.fargate_platform_version
+  enable_execute_command        = var.ecs_exec_enable
+  availability_zone_rebalancing = var.availability_zone_rebalancing
 
   # Use latest active revision
   task_definition = "${aws_ecs_task_definition.main.family}:${max(

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "name" {
   type        = string
 }
 
+variable "availability_zone_rebalancing" {
+  description = "Allow ECS to automatically rebalance tasks across AZ's"
+  type        = string
+  default     = "DISABLED"
+}
+
 variable "environment" {
   description = "Environment tag, e.g prod."
   type        = string


### PR DESCRIPTION
Changes proposed in this pull request:

- Allows module to set the `availability_zone_rebalancing` attribute
- The attribute defaulted to DISABLED, so the module still defaults to that in order to preserve backward compatibility
