### PR TITLE
feat: enable task-definitions to be managed with new provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,59 @@ module "app_ecs_service" {
 }
 ```
 
+### Managing task definitions from Terraform
+
+By default, the ECS service ignores changes to `task_definition` so that CI/CD tooling can manage deployments without Terraform interfering. If you want Terraform to own task definition updates — for example, when making a significant infrastructure change like updating CPU or memory — you can set `manage_task_definition = true`.
+
+```hcl
+module "app_ecs_service" {
+  source = "trussworks/ecs-service/aws"
+
+  name        = "app"
+  environment = "prod"
+
+  ecs_cluster    = aws_ecs_cluster.mycluster
+  ecs_vpc_id     = module.vpc.vpc_id
+  ecs_subnet_ids = module.vpc.private_subnets
+  kms_key_id     = aws_kms_key.main.arn
+
+  manage_task_definition = true
+}
+```
+
+Note that `container_definitions` is always managed outside of Terraform regardless of this setting, due to a provider-level JSON normalization issue that would otherwise cause a perma-change.
+
+#### Toggling `manage_task_definition` on an existing service
+
+Because this toggle is implemented via two separate resources under the hood, switching the value requires a `moved` block to avoid the ECS service being destroyed and recreated. Add the appropriate block to your configuration before running `terraform apply`, then remove it afterward.
+
+**Enabling `manage_task_definition = true` for the first time** (upgrading directly from a version of this module that predates this variable):
+
+```hcl
+moved {
+  from = module.app_ecs_service.aws_ecs_service.main
+  to   = module.app_ecs_service.aws_ecs_service.main_tf_managed[0]
+}
+```
+
+**Enabling `manage_task_definition = true` after already running the new module version** (where `main` is already indexed):
+
+```hcl
+moved {
+  from = module.app_ecs_service.aws_ecs_service.main[0]
+  to   = module.app_ecs_service.aws_ecs_service.main_tf_managed[0]
+}
+```
+
+**Switching back to `manage_task_definition = false`**:
+
+```hcl
+moved {
+  from = module.app_ecs_service.aws_ecs_service.main_tf_managed[0]
+  to   = module.app_ecs_service.aws_ecs_service.main[0]
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -207,6 +260,19 @@ No modules.
 <!-- END_TF_DOCS -->
 
 ## Upgrade Path
+
+### 8.x.x to 9.0.0
+
+This version introduces the `manage_task_definition` variable and splits `aws_ecs_service.main` into a count-based resource. Existing deployments where `manage_task_definition` is not set (or is `false`) are handled automatically via a `moved` block in the module — no action required.
+
+If you are enabling `manage_task_definition = true` at the same time as upgrading, use this `moved` block before applying since `main` will not yet have a `[0]` index in your state:
+
+```hcl
+moved {
+  from = module.app_ecs_service.aws_ecs_service.main
+  to   = module.app_ecs_service.aws_ecs_service.main_tf_managed[0]
+}
+```
 
 ### 5.x.x to 6.0.0
 

--- a/main.tf
+++ b/main.tf
@@ -515,7 +515,8 @@ resource "aws_ecs_service" "main" {
   enable_execute_command        = var.ecs_exec_enable
   availability_zone_rebalancing = var.availability_zone_rebalancing
 
-  # Use latest active revision
+  # Use latest active revision. State refresh keeps this stable when CI/CD deploys
+  # newer revisions — the provider normalizes ARN format in 6.x, so no perma-change.
   task_definition = "${aws_ecs_task_definition.main.family}:${max(
     aws_ecs_task_definition.main.revision,
     data.aws_ecs_task_definition.main.revision,
@@ -574,9 +575,5 @@ resource "aws_ecs_service" "main" {
       container_port = service_registries.value.container_port
       port           = service_registries.value.port
     }
-  }
-
-  lifecycle {
-    ignore_changes = [task_definition]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm_cpu" {
 
   dimensions = {
     "ClusterName" = var.ecs_cluster.name
-    "ServiceName" = aws_ecs_service.main.name
+    "ServiceName" = local.ecs_service.name
   }
 }
 
@@ -132,7 +132,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm_mem" {
 
   dimensions = {
     "ClusterName" = var.ecs_cluster.name
-    "ServiceName" = aws_ecs_service.main.name
+    "ServiceName" = local.ecs_service.name
   }
 }
 
@@ -506,7 +506,9 @@ locals {
   ecs_service_agg_security_groups = var.manage_ecs_security_group ? compact(concat(tolist([aws_security_group.ecs_sg[0].id]), var.additional_security_group_ids)) : compact(var.additional_security_group_ids)
 }
 
+# Default: task definition updates are managed by CI/CD; Terraform ignores drift.
 resource "aws_ecs_service" "main" {
+  count   = var.manage_task_definition ? 0 : 1
   name    = var.name
   cluster = var.ecs_cluster.arn
 
@@ -515,8 +517,6 @@ resource "aws_ecs_service" "main" {
   enable_execute_command        = var.ecs_exec_enable
   availability_zone_rebalancing = var.availability_zone_rebalancing
 
-  # Use latest active revision. State refresh keeps this stable when CI/CD deploys
-  # newer revisions — the provider normalizes ARN format in 6.x, so no perma-change.
   task_definition = "${aws_ecs_task_definition.main.family}:${max(
     aws_ecs_task_definition.main.revision,
     data.aws_ecs_task_definition.main.revision,
@@ -528,7 +528,6 @@ resource "aws_ecs_service" "main" {
 
   dynamic "ordered_placement_strategy" {
     for_each = local.ecs_service_ordered_placement_strategy[local.ecs_service_launch_type]
-
     content {
       type  = ordered_placement_strategy.value.type
       field = ordered_placement_strategy.value.field
@@ -537,7 +536,6 @@ resource "aws_ecs_service" "main" {
 
   dynamic "placement_constraints" {
     for_each = local.ecs_service_placement_constraints[local.ecs_service_launch_type]
-
     content {
       type = placement_constraints.value.type
     }
@@ -576,4 +574,82 @@ resource "aws_ecs_service" "main" {
       port           = service_registries.value.port
     }
   }
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+}
+
+# manage_task_definition = true: Terraform tracks and applies task definition changes.
+resource "aws_ecs_service" "main_tf_managed" {
+  count   = var.manage_task_definition ? 1 : 0
+  name    = var.name
+  cluster = var.ecs_cluster.arn
+
+  launch_type                   = local.ecs_service_launch_type
+  platform_version              = local.fargate_platform_version
+  enable_execute_command        = var.ecs_exec_enable
+  availability_zone_rebalancing = var.availability_zone_rebalancing
+
+  task_definition = "${aws_ecs_task_definition.main.family}:${max(
+    aws_ecs_task_definition.main.revision,
+    data.aws_ecs_task_definition.main.revision,
+  )}"
+
+  desired_count                      = var.tasks_desired_count
+  deployment_minimum_healthy_percent = var.tasks_minimum_healthy_percent
+  deployment_maximum_percent         = var.tasks_maximum_percent
+
+  dynamic "ordered_placement_strategy" {
+    for_each = local.ecs_service_ordered_placement_strategy[local.ecs_service_launch_type]
+    content {
+      type  = ordered_placement_strategy.value.type
+      field = ordered_placement_strategy.value.field
+    }
+  }
+
+  dynamic "placement_constraints" {
+    for_each = local.ecs_service_placement_constraints[local.ecs_service_launch_type]
+    content {
+      type = placement_constraints.value.type
+    }
+  }
+
+  network_configuration {
+    subnets          = var.ecs_subnet_ids
+    security_groups  = local.ecs_service_agg_security_groups
+    assign_public_ip = var.assign_public_ip
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.associate_alb || var.associate_nlb ? var.lb_target_groups : []
+    content {
+      container_name   = local.target_container_name
+      target_group_arn = load_balancer.value.lb_target_group_arn
+      container_port   = load_balancer.value.container_port
+    }
+  }
+
+  health_check_grace_period_seconds = var.associate_alb || var.associate_nlb ? var.health_check_grace_period_seconds : null
+
+  enable_ecs_managed_tags = var.enable_ecs_managed_tags
+
+  deployment_circuit_breaker {
+    enable   = var.ecs_deployment_circuit_breaker.enable
+    rollback = var.ecs_deployment_circuit_breaker.rollback
+  }
+
+  dynamic "service_registries" {
+    for_each = var.service_registries
+    content {
+      registry_arn   = service_registries.value.registry_arn
+      container_name = service_registries.value.container_name
+      container_port = service_registries.value.container_port
+      port           = service_registries.value.port
+    }
+  }
+}
+
+locals {
+  ecs_service = one(concat(aws_ecs_service.main, aws_ecs_service.main_tf_managed))
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -55,5 +55,5 @@ output "awslogs_group_arn" {
 
 output "ecs_service_id" {
   description = "ARN of the ECS service."
-  value       = aws_ecs_service.main.id
+  value       = local.ecs_service.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -224,6 +224,12 @@ variable "logs_cloudwatch_retention" {
   type        = number
 }
 
+variable "manage_task_definition" {
+  description = "If true, Terraform will track and apply changes to the task definition, including updating the ECS service when the task definition changes. If false (default), the ECS service ignores task definition changes so that CI/CD tooling can manage deployments independently. NOTE: Switching this value will cause the ECS service to be destroyed and recreated. To avoid downtime, use a moved block (see README)."
+  type        = bool
+  default     = false
+}
+
 variable "manage_ecs_security_group" {
   description = "Enable creation and management of the ECS security group and rules"
   default     = true


### PR DESCRIPTION

Remove lifecycle ignore policy on task_definition. task_definitions are no longer perma-changes with modern provider versions so they can be managed in TF.

https://jira.acf.gov/browse/OHSH-4087
